### PR TITLE
Improve match size calculation

### DIFF
--- a/app/lib/matchmaking/calculates_total_matches.rb
+++ b/app/lib/matchmaking/calculates_total_matches.rb
@@ -1,0 +1,12 @@
+module Matchmaking
+  class CalculatesTotalMatches
+    def call(total_participants:, target_size:)
+      return 0 if total_participants < 2 || target_size < 2
+      return 1 if total_participants <= target_size
+
+      return total_participants / target_size unless target_size > 2
+
+      (total_participants / target_size.to_f).round
+    end
+  end
+end

--- a/spec/lib/matchmaking/calculates_total_matches_spec.rb
+++ b/spec/lib/matchmaking/calculates_total_matches_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe Matchmaking::CalculatesTotalMatches, type: :matchmaking do
+  subject { Matchmaking::CalculatesTotalMatches.new }
+
+  [
+    [2, 0, 0], #    match sizes => []
+    [2, 1, 0], #    match sizes => []
+    [2, 2, 1], #    match sizes => [2]
+    [2, 3, 1], #    match sizes => [2]
+    [2, 4, 2], #    match sizes => [2,2]
+    [2, 5, 2], #    match sizes => [3,2]
+
+    [3, 0, 0], #    match sizes => []
+    [3, 1, 0], #    match sizes => []
+    [3, 2, 1], #    match sizes => [2]
+    [3, 3, 1], #    match sizes => [3]
+    [3, 4, 1], #    match sizes => [4]
+    [3, 5, 2], #    match sizes => [3,2]
+    [3, 6, 2], #    match sizes => [3,3]
+    [3, 7, 2], #    match sizes => [4,3]
+    [3, 8, 3], #    match sizes => [3,3,2]
+    [3, 9, 3], #    match sizes => [3,3,3]
+    [3, 10, 3], #   match sizes => [4,3,3]
+
+    [4, 0, 0], #    match sizes => []
+    [4, 1, 0], #    match sizes => []
+    [4, 2, 1], #    match sizes => [2]
+    [4, 3, 1], #    match sizes => [3]
+    [4, 4, 1], #    match sizes => [4]
+    [4, 5, 1], #    match sizes => [5]
+    [4, 6, 2], #    match sizes => [3,3]
+    [4, 7, 2], #    match sizes => [4,3]
+    [4, 8, 2], #    match sizes => [4,4]
+    [4, 9, 2], #    match sizes => [5,4]
+    [4, 10, 3], #   match sizes => [4,3,3]
+    [4, 11, 3], #   match sizes => [4,4,3]
+    [4, 12, 3], #   match sizes => [4,4,4]
+    [4, 13, 3] #    match sizes => [5,4,4]
+  ].each do |target_size, number_of_participants, expected_total_matches|
+    it "returns #{expected_total_matches} as the total matches when there are #{number_of_participants} participants for a desired match size of #{target_size}" do
+      total_matches = subject.call(total_participants: number_of_participants, target_size: target_size)
+
+      expect(total_matches).to eq(expected_total_matches)
+    end
+  end
+end

--- a/spec/lib/matchmaking/determines_matches_spec.rb
+++ b/spec/lib/matchmaking/determines_matches_spec.rb
@@ -113,13 +113,14 @@ RSpec.describe Matchmaking::DeterminesMatches, type: :matchmaking do
 
     subject { Matchmaking::DeterminesMatches.new(config: config) }
 
-    it "returns single larger group when multiple cannot satisfy minimum group size" do
+    it "ensures groups are balanced intead of creating a single larger group" do
       participants = new_participants(ids: ["USER_ID_1", "USER_ID_2", "USER_ID_3", "USER_ID_4", "USER_ID_5"])
 
       matches = subject.call(grouping: "test", participants: participants)
 
       expect(matches).to eq([
-        Matchmaking::Match.new(grouping: "test", members: ["USER_ID_1", "USER_ID_2", "USER_ID_3", "USER_ID_4", "USER_ID_5"])
+        Matchmaking::Match.new(grouping: "test", members: ["USER_ID_2", "USER_ID_3", "USER_ID_4"]),
+        Matchmaking::Match.new(grouping: "test", members: ["USER_ID_1", "USER_ID_5"])
       ])
     end
 


### PR DESCRIPTION
Before, if there was a size of 4 for a grouping and there was only 7 participants, all 7 would be placed within the same group. Also, the groups would lean towards heavier, possibly making heavier groups than desired by default.

This changes that with some simple math to round based on the number given. It will skew more toward fewer large groups, so if the size is 4, there will be groups of 3 and 4 vs 4 and 5.

Something to note is that it will always skew toward group sizes of `n - 1` where `n` is the size, so if that is not desired, I have isolated the calculation logic so that we can fiddle with it to obtain how it should calculate.