### PR TITLE
Implement slash command to list channels

### DIFF
--- a/app/controllers/application_chatops_controller.rb
+++ b/app/controllers/application_chatops_controller.rb
@@ -8,4 +8,13 @@ class ApplicationChatopsController < ApplicationController
   rescue Slack::Events::Request::MissingSigningSecret, Slack::Events::Request::InvalidSignature, Slack::Events::Request::TimestampExpired
     render plain: "Nope.", status: :unauthorized
   end
+
+  def subcommand
+    Utils::ParsesCliStyleCommandArgs.new.call(text: params[:text]).subcommand
+  end
+
+  def command_params
+    parsed = Utils::ParsesCliStyleCommandArgs.new.call(text: params[:text])
+    ActionController::Parameters.new(parsed.args)
+  end
 end

--- a/app/controllers/chatops/slack_slash_command_list_controller.rb
+++ b/app/controllers/chatops/slack_slash_command_list_controller.rb
@@ -4,7 +4,7 @@ module Chatops
       config = Matchmaking.config
       message = config.to_h.keys.sort.each_with_object([]) do |key, result|
         grouping = config[key]
-        next unless grouping.active
+        next unless include_grouping_in_list?(grouping)
         result << "*#{key.to_s.titleize}*: Meets #{grouping.schedule} in groups of #{grouping.size} (Join: ##{grouping.channel})"
       end.join("\n")
 
@@ -13,6 +13,12 @@ module Chatops
       else
         render plain: "Sorry! There are no configured channels for groupings."
       end
+    end
+
+    private
+
+    def include_grouping_in_list?(grouping)
+      grouping.active || command_params.key?(:all)
     end
   end
 end

--- a/app/controllers/chatops/slack_slash_command_list_controller.rb
+++ b/app/controllers/chatops/slack_slash_command_list_controller.rb
@@ -1,7 +1,18 @@
 module Chatops
   class SlackSlashCommandListController < ::ApplicationChatopsController
     def handle
-      render plain: "Sorry! There are no configured channels for groupings."
+      config = Matchmaking.config
+      message = config.to_h.keys.sort.each_with_object([]) do |key, result|
+        grouping = config[key]
+        next unless grouping.active
+        result << "*#{key.to_s.titleize}*: Meets #{grouping.schedule} in groups of #{grouping.size} (Join: ##{grouping.channel})"
+      end.join("\n")
+
+      if config.to_h.keys.any?
+        render plain: message
+      else
+        render plain: "Sorry! There are no configured channels for groupings."
+      end
     end
   end
 end

--- a/app/controllers/chatops/slack_slash_command_list_controller.rb
+++ b/app/controllers/chatops/slack_slash_command_list_controller.rb
@@ -1,0 +1,7 @@
+module Chatops
+  class SlackSlashCommandListController < ::ApplicationChatopsController
+    def handle
+      render plain: "Sorry! There are no configured channels for groupings."
+    end
+  end
+end

--- a/app/lib/matchmaking.rb
+++ b/app/lib/matchmaking.rb
@@ -1,0 +1,6 @@
+module Matchmaking
+  def config
+    Rails.application.config.x.matchmaking
+  end
+  module_function :config
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,6 @@ Rails.application.routes.draw do
     mount TestOnlyRoutes, at: "/"
   end
 
-  post "/command/doubleup", to: "chatops/slack_slash_command_list#handle", constraints: SlackSlashSubcommandConstraint.new(matches_subcommand: 'list')
+  post "/command/doubleup", to: "chatops/slack_slash_command_list#handle", constraints: SlackSlashSubcommandConstraint.new(matches_subcommand: "list")
   post "/command/doubleup", to: "chatops/slack_slash_command#handle"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,20 @@
+class SlackSlashSubcommandConstraint
+  def initialize(matches_subcommand:)
+    @subcommand = matches_subcommand
+  end
+
+  def matches?(request)
+    parsed = Utils::ParsesCliStyleCommandArgs.new.call(text: request.params["text"])
+    parsed.subcommand == @subcommand
+  end
+end
+
 Rails.application.routes.draw do
   if Rails.env.test?
     TestOnlyRoutes = ActionDispatch::Routing::RouteSet.new unless defined?(::TestOnlyRoutes)
     mount TestOnlyRoutes, at: "/"
   end
 
+  post "/command/doubleup", to: "chatops/slack_slash_command_list#handle", constraints: SlackSlashSubcommandConstraint.new(matches_subcommand: 'list')
   post "/command/doubleup", to: "chatops/slack_slash_command#handle"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,6 @@ Rails.application.routes.draw do
     mount TestOnlyRoutes, at: "/"
   end
 
-  post "/command/doubleup", to: "chatops/slack_slash_command_list#handle", constraints: SlackSlashSubcommandConstraint.new(matches_subcommand: "list")
+  post "/command/doubleup", to: "chatops/slack_slash_command_list#handle", constraints: SlackSlashSubcommandConstraint.new(matches_subcommand: "channels:list")
   post "/command/doubleup", to: "chatops/slack_slash_command#handle"
 end

--- a/spec/requests/chatops/slack_slash_command_list_controller_spec.rb
+++ b/spec/requests/chatops/slack_slash_command_list_controller_spec.rb
@@ -4,20 +4,7 @@ RSpec.describe "SlackSlashCommandListController", type: :request do
   scenario "responds with default message when no channels configured" do
     allow(Matchmaking).to receive(:config).and_return({})
 
-    slack_signing_secret = Slack::Events.config.signing_secret
-    timestamp = Time.zone.now.to_i
-    request_body = "token=#{slack_signing_secret}&team_id=T02PF6RHYSY&team_domain=testdouble-hq&channel_id=C02NYBB3VPH&channel_name=some-channel&user_id=U02PRHH0XEV&user_name=cliff.pruitt&command=%2Fdoubleup&text=list&api_app_id=A02PD0DUE03&is_enterprise_install=false&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT02PF6RHYSY%2F2823421496992%2F0WC0HfWeGJpHetxmF8yUmawo&trigger_id=2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
-    data = ["v0", timestamp, request_body].join(":")
-    mac = OpenSSL::HMAC.hexdigest("SHA256", slack_signing_secret, data)
-    signature = "v0=#{mac}"
-
-    request_headers = {
-      "X-Slack-Signature" => signature,
-      "X-Slack-Request-Timestamp" => timestamp
-    }
-
-    request_params = {
-      "token" => slack_signing_secret,
+    signed = signed_request_body(params: {
       "team_id" => "T02PF6RHYSY",
       "team_domain" => "testdouble-hq",
       "channel_id" => "C02NYBB3VPH",
@@ -31,10 +18,15 @@ RSpec.describe "SlackSlashCommandListController", type: :request do
       "response_url" =>
        "https://hooks.slack.com/commands/T02PF6RHYSY/2823421496992/0WC0HfWeGJpHetxmF8yUmawo",
       "trigger_id" => "2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
+    })
+
+    request_headers = {
+      "X-Slack-Signature" => signed.signature,
+      "X-Slack-Request-Timestamp" => signed.timestamp
     }
 
     post "/command/doubleup",
-      params: request_params,
+      params: signed.body,
       headers: request_headers
 
     expect(response).to have_http_status(:ok)
@@ -63,20 +55,7 @@ RSpec.describe "SlackSlashCommandListController", type: :request do
       })
     }))
 
-    slack_signing_secret = Slack::Events.config.signing_secret
-    timestamp = Time.zone.now.to_i
-    request_body = "token=#{slack_signing_secret}&team_id=T02PF6RHYSY&team_domain=testdouble-hq&channel_id=C02NYBB3VPH&channel_name=some-channel&user_id=U02PRHH0XEV&user_name=cliff.pruitt&command=%2Fdoubleup&text=list&api_app_id=A02PD0DUE03&is_enterprise_install=false&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT02PF6RHYSY%2F2823421496992%2F0WC0HfWeGJpHetxmF8yUmawo&trigger_id=2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
-    data = ["v0", timestamp, request_body].join(":")
-    mac = OpenSSL::HMAC.hexdigest("SHA256", slack_signing_secret, data)
-    signature = "v0=#{mac}"
-
-    request_headers = {
-      "X-Slack-Signature" => signature,
-      "X-Slack-Request-Timestamp" => timestamp
-    }
-
-    request_params = {
-      "token" => slack_signing_secret,
+    signed = signed_request_body(params: {
       "team_id" => "T02PF6RHYSY",
       "team_domain" => "testdouble-hq",
       "channel_id" => "C02NYBB3VPH",
@@ -88,12 +67,17 @@ RSpec.describe "SlackSlashCommandListController", type: :request do
       "api_app_id" => "A02PD0DUE03",
       "is_enterprise_install" => "false",
       "response_url" =>
-       "https://hooks.slack.com/commands/T02PF6RHYSY/2823421496992/0WC0HfWeGJpHetxmF8yUmawo",
+        "https://hooks.slack.com/commands/T02PF6RHYSY/2823421496992/0WC0HfWeGJpHetxmF8yUmawo",
       "trigger_id" => "2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
+    })
+
+    request_headers = {
+      "X-Slack-Signature" => signed.signature,
+      "X-Slack-Request-Timestamp" => signed.timestamp
     }
 
     post "/command/doubleup",
-      params: request_params,
+      params: signed.body,
       headers: request_headers
 
     expect(response).to have_http_status(:ok)
@@ -102,5 +86,20 @@ RSpec.describe "SlackSlashCommandListController", type: :request do
       *Active Two*: Meets weekly in groups of 2 (Join: #active-2)
     MSG
     expect(response.body).to eq(expected_response)
+  end
+
+  private
+
+  def signed_request_body(params: {})
+    slack_signing_secret = Slack::Events.config.signing_secret
+    timestamp = Time.zone.now.to_i
+    request_body = params.to_param
+    data = ["v0", timestamp, request_body].join(":")
+    mac = OpenSSL::HMAC.hexdigest("SHA256", slack_signing_secret, data)
+    OpenStruct.new({
+      signature: "v0=#{mac}",
+      timestamp: timestamp,
+      body: request_body
+    })
   end
 end

--- a/spec/requests/chatops/slack_slash_command_list_controller_spec.rb
+++ b/spec/requests/chatops/slack_slash_command_list_controller_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe "SlackSlashCommandListController", type: :request do
+  scenario "responds to list with default message" do
+    slack_signing_secret = Slack::Events.config.signing_secret
+    timestamp = Time.zone.now.to_i
+    request_body = "token=#{slack_signing_secret}&team_id=T02PF6RHYSY&team_domain=testdouble-hq&channel_id=C02NYBB3VPH&channel_name=some-channel&user_id=U02PRHH0XEV&user_name=cliff.pruitt&command=%2Fdoubleup&text=list&api_app_id=A02PD0DUE03&is_enterprise_install=false&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT02PF6RHYSY%2F2823421496992%2F0WC0HfWeGJpHetxmF8yUmawo&trigger_id=2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
+    data = ["v0", timestamp, request_body].join(":")
+    mac = OpenSSL::HMAC.hexdigest("SHA256", slack_signing_secret, data)
+    signature = "v0=#{mac}"
+
+    request_headers = {
+      "X-Slack-Signature" => signature,
+      "X-Slack-Request-Timestamp" => timestamp
+    }
+
+    request_params = {
+      "token" => slack_signing_secret,
+      "team_id" => "T02PF6RHYSY",
+      "team_domain" => "testdouble-hq",
+      "channel_id" => "C02NYBB3VPH",
+      "channel_name" => "some-channel",
+      "user_id" => "U02PRHH0XEV",
+      "user_name" => "cliff.pruitt",
+      "command" => "/doubleup",
+      "text" => "list",
+      "api_app_id" => "A02PD0DUE03",
+      "is_enterprise_install" => "false",
+      "response_url" =>
+       "https://hooks.slack.com/commands/T02PF6RHYSY/2823421496992/0WC0HfWeGJpHetxmF8yUmawo",
+      "trigger_id" => "2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
+    }
+
+    post "/command/doubleup",
+      params: request_params,
+      headers: request_headers
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq("Sorry! There are no configured channels for groupings.")
+  end
+end

--- a/spec/requests/chatops/slack_slash_command_list_controller_spec.rb
+++ b/spec/requests/chatops/slack_slash_command_list_controller_spec.rb
@@ -88,6 +88,62 @@ RSpec.describe "SlackSlashCommandListController", type: :request do
     expect(response.body).to eq(expected_response)
   end
 
+  scenario "responds with list of active and inactive channels with --all" do
+    allow(Matchmaking).to receive(:config).and_return(OpenStruct.new({
+      active_one: OpenStruct.new({
+        active: true,
+        schedule: "weekly",
+        size: 2,
+        channel: "active-1"
+      }),
+      not_active_one: OpenStruct.new({
+        active: false,
+        schedule: "weekly",
+        size: 2,
+        channel: "not-active-1"
+      }),
+      active_two: OpenStruct.new({
+        active: true,
+        schedule: "weekly",
+        size: 2,
+        channel: "active-2"
+      })
+    }))
+
+    signed = signed_request_body(params: {
+      "team_id" => "T02PF6RHYSY",
+      "team_domain" => "testdouble-hq",
+      "channel_id" => "C02NYBB3VPH",
+      "channel_name" => "some-channel",
+      "user_id" => "U02PRHH0XEV",
+      "user_name" => "cliff.pruitt",
+      "command" => "/doubleup",
+      "text" => "list --all",
+      "api_app_id" => "A02PD0DUE03",
+      "is_enterprise_install" => "false",
+      "response_url" =>
+        "https://hooks.slack.com/commands/T02PF6RHYSY/2823421496992/0WC0HfWeGJpHetxmF8yUmawo",
+      "trigger_id" => "2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
+    })
+
+    request_headers = {
+      "X-Slack-Signature" => signed.signature,
+      "X-Slack-Request-Timestamp" => signed.timestamp
+    }
+
+    post "/command/doubleup",
+      params: signed.body,
+      headers: request_headers
+
+    expect(response).to have_http_status(:ok)
+    expected_response = <<~MSG.chomp
+      *Active One*: Meets weekly in groups of 2 (Join: #active-1)
+      *Active Two*: Meets weekly in groups of 2 (Join: #active-2)
+      *Not Active One*: Meets weekly in groups of 2 (Join: #not-active-1)
+    MSG
+    expect(response.body).to eq(expected_response)
+  end
+
   private
 
   def signed_request_body(params: {})

--- a/spec/requests/chatops/slack_slash_command_list_controller_spec.rb
+++ b/spec/requests/chatops/slack_slash_command_list_controller_spec.rb
@@ -1,7 +1,9 @@
 require "rails_helper"
 
 RSpec.describe "SlackSlashCommandListController", type: :request do
-  scenario "responds to list with default message" do
+  scenario "responds with default message when no channels configured" do
+    allow(Matchmaking).to receive(:config).and_return({})
+
     slack_signing_secret = Slack::Events.config.signing_secret
     timestamp = Time.zone.now.to_i
     request_body = "token=#{slack_signing_secret}&team_id=T02PF6RHYSY&team_domain=testdouble-hq&channel_id=C02NYBB3VPH&channel_name=some-channel&user_id=U02PRHH0XEV&user_name=cliff.pruitt&command=%2Fdoubleup&text=list&api_app_id=A02PD0DUE03&is_enterprise_install=false&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT02PF6RHYSY%2F2823421496992%2F0WC0HfWeGJpHetxmF8yUmawo&trigger_id=2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
@@ -37,5 +39,68 @@ RSpec.describe "SlackSlashCommandListController", type: :request do
 
     expect(response).to have_http_status(:ok)
     expect(response.body).to eq("Sorry! There are no configured channels for groupings.")
+  end
+
+  scenario "responds with list of only active channels" do
+    allow(Matchmaking).to receive(:config).and_return(OpenStruct.new({
+      active_one: OpenStruct.new({
+        active: true,
+        schedule: "weekly",
+        size: 2,
+        channel: "active-1"
+      }),
+      not_active_one: OpenStruct.new({
+        active: false,
+        schedule: "weekly",
+        size: 2,
+        channel: "not-active-1"
+      }),
+      active_two: OpenStruct.new({
+        active: true,
+        schedule: "weekly",
+        size: 2,
+        channel: "active-2"
+      })
+    }))
+
+    slack_signing_secret = Slack::Events.config.signing_secret
+    timestamp = Time.zone.now.to_i
+    request_body = "token=#{slack_signing_secret}&team_id=T02PF6RHYSY&team_domain=testdouble-hq&channel_id=C02NYBB3VPH&channel_name=some-channel&user_id=U02PRHH0XEV&user_name=cliff.pruitt&command=%2Fdoubleup&text=list&api_app_id=A02PD0DUE03&is_enterprise_install=false&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT02PF6RHYSY%2F2823421496992%2F0WC0HfWeGJpHetxmF8yUmawo&trigger_id=2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
+    data = ["v0", timestamp, request_body].join(":")
+    mac = OpenSSL::HMAC.hexdigest("SHA256", slack_signing_secret, data)
+    signature = "v0=#{mac}"
+
+    request_headers = {
+      "X-Slack-Signature" => signature,
+      "X-Slack-Request-Timestamp" => timestamp
+    }
+
+    request_params = {
+      "token" => slack_signing_secret,
+      "team_id" => "T02PF6RHYSY",
+      "team_domain" => "testdouble-hq",
+      "channel_id" => "C02NYBB3VPH",
+      "channel_name" => "some-channel",
+      "user_id" => "U02PRHH0XEV",
+      "user_name" => "cliff.pruitt",
+      "command" => "/doubleup",
+      "text" => "list",
+      "api_app_id" => "A02PD0DUE03",
+      "is_enterprise_install" => "false",
+      "response_url" =>
+       "https://hooks.slack.com/commands/T02PF6RHYSY/2823421496992/0WC0HfWeGJpHetxmF8yUmawo",
+      "trigger_id" => "2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
+    }
+
+    post "/command/doubleup",
+      params: request_params,
+      headers: request_headers
+
+    expect(response).to have_http_status(:ok)
+    expected_response = <<~MSG.chomp
+      *Active One*: Meets weekly in groups of 2 (Join: #active-1)
+      *Active Two*: Meets weekly in groups of 2 (Join: #active-2)
+    MSG
+    expect(response.body).to eq(expected_response)
   end
 end

--- a/spec/requests/chatops/slack_slash_command_list_controller_spec.rb
+++ b/spec/requests/chatops/slack_slash_command_list_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "SlackSlashCommandListController", type: :request do
       "user_id" => "U02PRHH0XEV",
       "user_name" => "cliff.pruitt",
       "command" => "/doubleup",
-      "text" => "list",
+      "text" => "channels:list",
       "api_app_id" => "A02PD0DUE03",
       "is_enterprise_install" => "false",
       "response_url" =>
@@ -63,7 +63,7 @@ RSpec.describe "SlackSlashCommandListController", type: :request do
       "user_id" => "U02PRHH0XEV",
       "user_name" => "cliff.pruitt",
       "command" => "/doubleup",
-      "text" => "list",
+      "text" => "channels:list",
       "api_app_id" => "A02PD0DUE03",
       "is_enterprise_install" => "false",
       "response_url" =>
@@ -118,7 +118,7 @@ RSpec.describe "SlackSlashCommandListController", type: :request do
       "user_id" => "U02PRHH0XEV",
       "user_name" => "cliff.pruitt",
       "command" => "/doubleup",
-      "text" => "list --all",
+      "text" => "channels:list --all",
       "api_app_id" => "A02PD0DUE03",
       "is_enterprise_install" => "false",
       "response_url" =>

--- a/spec/requests/chatops_controller_command_params_spec.rb
+++ b/spec/requests/chatops_controller_command_params_spec.rb
@@ -1,0 +1,95 @@
+require "rails_helper"
+
+class CommandParamsChatopsController < ApplicationChatopsController
+  def index
+    render plain: "Got command <#{subcommand}> with name <#{command_params[:name]}> and group size <#{command_params[:group_size]}>"
+  end
+end
+
+RSpec.describe "ApplicationChatopsController command params", type: :request do
+  before :all do
+    TestOnlyRoutes.draw do
+      post "/chatops/test-params", to: "command_params_chatops#index"
+    end
+  end
+
+  after :all do
+    TestOnlyRoutes.clear!
+  end
+
+  scenario "provides subcommand and command_params to actions" do
+    slack_signing_secret = Slack::Events.config.signing_secret
+    timestamp = Time.zone.now.to_i
+    request_body = "token=#{slack_signing_secret}&team_id=T02PF6RHYSY&team_domain=testdouble-hq&channel_id=C02NYBB3VPH&channel_name=some-channel&user_id=U02PRHH0XEV&user_name=cliff.pruitt&command=%2Fdoubleup&text=snazzy-command+--name%3Dblargh+--group-size%3D4&api_app_id=A02PD0DUE03&is_enterprise_install=false&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT02PF6RHYSY%2F2823421496992%2F0WC0HfWeGJpHetxmF8yUmawo&trigger_id=2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
+    data = ["v0", timestamp, request_body].join(":")
+    mac = OpenSSL::HMAC.hexdigest("SHA256", slack_signing_secret, data)
+    signature = "v0=#{mac}"
+
+    request_headers = {
+      "X-Slack-Signature" => signature,
+      "X-Slack-Request-Timestamp" => timestamp
+    }
+
+    request_params = {
+      "token" => slack_signing_secret,
+      "team_id" => "T02PF6RHYSY",
+      "team_domain" => "testdouble-hq",
+      "channel_id" => "C02NYBB3VPH",
+      "channel_name" => "some-channel",
+      "user_id" => "U02PRHH0XEV",
+      "user_name" => "cliff.pruitt",
+      "command" => "/doubleup",
+      "text" => "snazzy-command --name=blargh --group-size=4",
+      "api_app_id" => "A02PD0DUE03",
+      "is_enterprise_install" => "false",
+      "response_url" =>
+       "https://hooks.slack.com/commands/T02PF6RHYSY/2823421496992/0WC0HfWeGJpHetxmF8yUmawo",
+      "trigger_id" => "2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
+    }
+
+    post "/chatops/test-params",
+      params: request_params,
+      headers: request_headers
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq("Got command <snazzy-command> with name <blargh> and group size <4>")
+  end
+
+  scenario "provides subcommand and command_params to actions for empty params" do
+    slack_signing_secret = Slack::Events.config.signing_secret
+    timestamp = Time.zone.now.to_i
+    request_body = "token=#{slack_signing_secret}&team_id=T02PF6RHYSY&team_domain=testdouble-hq&channel_id=C02NYBB3VPH&channel_name=some-channel&user_id=U02PRHH0XEV&user_name=cliff.pruitt&command=%2Fdoubleup&text=&api_app_id=A02PD0DUE03&is_enterprise_install=false&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT02PF6RHYSY%2F2823421496992%2F0WC0HfWeGJpHetxmF8yUmawo&trigger_id=2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
+    data = ["v0", timestamp, request_body].join(":")
+    mac = OpenSSL::HMAC.hexdigest("SHA256", slack_signing_secret, data)
+    signature = "v0=#{mac}"
+
+    request_headers = {
+      "X-Slack-Signature" => signature,
+      "X-Slack-Request-Timestamp" => timestamp
+    }
+
+    request_params = {
+      "token" => slack_signing_secret,
+      "team_id" => "T02PF6RHYSY",
+      "team_domain" => "testdouble-hq",
+      "channel_id" => "C02NYBB3VPH",
+      "channel_name" => "some-channel",
+      "user_id" => "U02PRHH0XEV",
+      "user_name" => "cliff.pruitt",
+      "command" => "/doubleup",
+      "text" => "",
+      "api_app_id" => "A02PD0DUE03",
+      "is_enterprise_install" => "false",
+      "response_url" =>
+       "https://hooks.slack.com/commands/T02PF6RHYSY/2823421496992/0WC0HfWeGJpHetxmF8yUmawo",
+      "trigger_id" => "2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
+    }
+
+    post "/chatops/test-params",
+      params: request_params,
+      headers: request_headers
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq("Got command <> with name <> and group size <>")
+  end
+end

--- a/spec/requests/chatops_controller_command_params_spec.rb
+++ b/spec/requests/chatops_controller_command_params_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "ApplicationChatopsController command params", type: :request do
   scenario "provides subcommand and command_params to actions" do
     slack_signing_secret = Slack::Events.config.signing_secret
     timestamp = Time.zone.now.to_i
-    request_body = "token=#{slack_signing_secret}&team_id=T02PF6RHYSY&team_domain=testdouble-hq&channel_id=C02NYBB3VPH&channel_name=some-channel&user_id=U02PRHH0XEV&user_name=cliff.pruitt&command=%2Fdoubleup&text=snazzy-command+--name%3Dblargh+--group-size%3D4&api_app_id=A02PD0DUE03&is_enterprise_install=false&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT02PF6RHYSY%2F2823421496992%2F0WC0HfWeGJpHetxmF8yUmawo&trigger_id=2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
+    request_body = "token=#{slack_signing_secret}&team_id=T02PF6RHYSY&team_domain=testdouble-hq&channel_id=C02NYBB3VPH&channel_name=some-channel&user_id=U02PRHH0XEV&user_name=cliff.pruitt&command=%2Fdoubleup&text=snazzy%3Acommand+--name%3Dblargh+--group-size%3D4&api_app_id=A02PD0DUE03&is_enterprise_install=false&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT02PF6RHYSY%2F2823421496992%2F0WC0HfWeGJpHetxmF8yUmawo&trigger_id=2801968477828.2797229610916.883001cf5008d6d02fd58a3cf70f449e"
     data = ["v0", timestamp, request_body].join(":")
     mac = OpenSSL::HMAC.hexdigest("SHA256", slack_signing_secret, data)
     signature = "v0=#{mac}"
@@ -39,7 +39,7 @@ RSpec.describe "ApplicationChatopsController command params", type: :request do
       "user_id" => "U02PRHH0XEV",
       "user_name" => "cliff.pruitt",
       "command" => "/doubleup",
-      "text" => "snazzy-command --name=blargh --group-size=4",
+      "text" => "snazzy:command --name=blargh --group-size=4",
       "api_app_id" => "A02PD0DUE03",
       "is_enterprise_install" => "false",
       "response_url" =>
@@ -52,7 +52,7 @@ RSpec.describe "ApplicationChatopsController command params", type: :request do
       headers: request_headers
 
     expect(response).to have_http_status(:ok)
-    expect(response.body).to eq("Got command <snazzy-command> with name <blargh> and group size <4>")
+    expect(response.body).to eq("Got command <snazzy:command> with name <blargh> and group size <4>")
   end
 
   scenario "provides subcommand and command_params to actions for empty params" do


### PR DESCRIPTION
This PR adds a basic handler for `/doubleup list`. The command will return a list of all active channels by default, and all channels if using the `--all` flag. (Technically you could use `--all`, `-all`, `all` or `-------------------------all` since we just strip `-`s). Each item in the list privides the name, schedule, and channel to join.

Channel names are not links. This is because Slack formatting requires using channel ID's not names. I think this is kind of annoying, but I don't control slack. I don't address channel ID lookup in this PR so for now the channel names are just plain text. We can more easily address that when we move configs to the DB. When that happens we can store the channel ID.

There are inline comments with some thoughts on the code changes.

## Scope of Review

I'm still optimizing for getting features done. I don't want to go all "Wild West" but I'd suggest that since we don't have a ton of bandwidth to devote to this we focus mainly on blocking issues or things that will lead us down bad paths that will be hard to back out of.

- Are the patterns here good? (e.g. `command_params[:something]`)
- Do we like the method of route handling?
- Is there anything that's not a blocker but we'd like to follow up on in subsequent PRs? (I'll add issues)