### PR TITLE
Paginate through slack channels

### DIFF
--- a/app/services/slack/loads_slack_channels.rb
+++ b/app/services/slack/loads_slack_channels.rb
@@ -14,7 +14,7 @@ module Slack
         ClientWrapper.client.conversations_list(types: approved_types(types), limit: 1000, exclude_archived: true)
       end
 
-      get_paged_channels(response&.response_metadata&.next_cursor, response&.channels || [])
+      get_paged_channels(cursor: response&.response_metadata&.next_cursor, channels: response&.channels || [], types: types)
     end
 
     private
@@ -23,11 +23,11 @@ module Slack
       types.split(",").select { |t| SLACK_CHANNEL_TYPES.include?(t) }.join(",")
     end
 
-    def get_paged_channels(cursor, channels)
+    def get_paged_channels(cursor:, channels:, types:)
       while cursor.present?
         response = ClientWrapper.client.conversations_list(cursor: cursor, types: approved_types(types), limit: 1000, exclude_archived: true)
         channels.append(response.channels)
-        cursor = response.response_metadata.next_cursor
+        cursor = response.response_metadata&.next_cursor
       end
 
       channels.flatten

--- a/app/services/slack/loads_slack_channels.rb
+++ b/app/services/slack/loads_slack_channels.rb
@@ -11,16 +11,26 @@ module Slack
 
     def call(types:)
       response = retry_when_rate_limited do
-        ClientWrapper.client.conversations_list(types: approved_types(types), limit: 1000)
+        ClientWrapper.client.conversations_list(types: approved_types(types), limit: 1000, exclude_archived: true)
       end
 
-      (response&.channels || []).reject { |ch| ch.is_archived }
+      get_paged_channels(response&.response_metadata&.next_cursor, response&.channels || [])
     end
 
     private
 
     def approved_types(types)
       types.split(",").select { |t| SLACK_CHANNEL_TYPES.include?(t) }.join(",")
+    end
+
+    def get_paged_channels(cursor, channels)
+      while cursor.present?
+        response = ClientWrapper.client.conversations_list(cursor: cursor, types: approved_types(types), limit: 1000, exclude_archived: true)
+        channels.append(response.channels)
+        cursor = response.response_metadata.next_cursor
+      end
+
+      channels.flatten
     end
   end
 end

--- a/spec/lib/slack/loads_slack_channels_spec.rb
+++ b/spec/lib/slack/loads_slack_channels_spec.rb
@@ -18,17 +18,16 @@ RSpec.describe Slack::LoadsSlackChannels do
       is_mpim: true,
       user: Slack::Messages::Message.new(id: "USER_ID")
     )
-    archived_slack_public_channel = Slack::Messages::Message.new(
+    Slack::Messages::Message.new(
       id: "PUBLIC_CHANNEL_ID_2",
       is_channel: true,
       is_archived: true
     )
 
-    expect(@slack_client).to receive(:conversations_list).with(types: "public_channel,mpim", limit: 1000) {
+    expect(@slack_client).to receive(:conversations_list).with(types: "public_channel,mpim", limit: 1000, exclude_archived: true) {
       Slack::Messages::Message.new(ok: true, channels: [
         slack_public_channel,
-        slack_mpim_channel,
-        archived_slack_public_channel
+        slack_mpim_channel
       ])
     }
 
@@ -37,13 +36,36 @@ RSpec.describe Slack::LoadsSlackChannels do
     expect(channels).to eq([slack_public_channel, slack_mpim_channel])
   end
 
+  it "loads all active channels when requiring pagination" do
+    archived_slack_public_channel = Slack::Messages::Message.new(
+      id: "PUBLIC_CHANNEL_ID_2",
+      is_channel: true,
+      is_archived: true
+    )
+    slack_public_channels = (0..1010).map do |ch|
+      Slack::Messages::Message.new(
+        id: "PUBLIC_CHANNEL_ID_#{ch}",
+        is_channel: true
+      )
+    end
+    all_channels = slack_public_channels << archived_slack_public_channel
+
+    expect(@slack_client).to receive(:conversations_list).with(types: "public_channel", limit: 1000, exclude_archived: true) {
+      Slack::Messages::Message.new(ok: true, channels: all_channels)
+    }
+
+    channels = subject.call(types: "public_channel")
+
+    expect(channels).to eq(slack_public_channels)
+  end
+
   it "ignores unrecognized channel types" do
     slack_public_channel = Slack::Messages::Message.new(
       id: "PUBLIC_CHANNEL_ID_1",
       is_channel: true
     )
 
-    expect(@slack_client).to receive(:conversations_list).with(types: "public_channel", limit: 1000) {
+    expect(@slack_client).to receive(:conversations_list).with(types: "public_channel", limit: 1000, exclude_archived: true) {
       Slack::Messages::Message.new(ok: true, channels: [slack_public_channel])
     }
 


### PR DESCRIPTION
## Problem
If there are over 1000 slack channels in an organization, which is
entirely possible with the ability to archive channels, the call method
in loads_slack_channels would only retrieve the first 1000.

## Solution
This change adds a method to follow any pagination cursors and combine
channel list pages together to ensure we have a complete channel list.

This change also makes use of the exclude_archived argument for
conversations_list which will (on Slack's side) throw out any archived
channels. A snippet to keep in mind from [Slack's docs](https://api.slack.com/methods/conversations.list):

"When paginating, any filters used in the request are applied after
retrieving a virtual page's limit. For example. using
exclude_archived=true when limit=20 on a virtual page that would contain
15 archived channels will return you the virtual page with only 5
results. Additional results are available from the next cursor
valuePaginate through slack channels."