### PR TITLE
Clean up task

### DIFF
--- a/app/lib/rakes/removes_old_matches.rb
+++ b/app/lib/rakes/removes_old_matches.rb
@@ -1,0 +1,8 @@
+module Rakes
+  class RemovesOldMatches
+    def call
+      HistoricalMatch.older_than(3.months.ago).destroy_all
+      PendingNotification.where(historical_match: nil).destroy_all
+    end
+  end
+end

--- a/app/models/historical_match.rb
+++ b/app/models/historical_match.rb
@@ -4,6 +4,8 @@ class HistoricalMatch < ApplicationRecord
   validates :matched_on, :grouping, presence: true
   validate :at_least_two_members
 
+  scope :older_than, ->(date) { where("created_at::date < '#{date.to_date}'") }
+
   private
 
   def at_least_two_members

--- a/app/models/historical_match.rb
+++ b/app/models/historical_match.rb
@@ -1,5 +1,5 @@
 class HistoricalMatch < ApplicationRecord
-  has_many :pending_notifications
+  has_many :pending_notifications, dependent: :nullify
 
   validates :matched_on, :grouping, presence: true
   validate :at_least_two_members

--- a/lib/tasks/scheduler.rake
+++ b/lib/tasks/scheduler.rake
@@ -1,6 +1,7 @@
 task create_groups: :environment do
   [
     Rakes::RunsMatchmaking.new(stdout: $stdout, stderr: $stdout),
-    Rakes::SendsPendingNotifications.new(stdout: $stdout, stderr: $stdout)
+    Rakes::SendsPendingNotifications.new(stdout: $stdout, stderr: $stdout),
+    Rakes::RemovesOldMatches.new
   ].each(&:call)
 end

--- a/spec/lib/rakes/removes_old_matches_spec.rb
+++ b/spec/lib/rakes/removes_old_matches_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe Rakes::RemovesOldMatches do
+  it "removes matches from 3 months ago and keeps newer ones" do
+    recent_match = HistoricalMatch.create(
+      grouping: "test",
+      matched_on: Date.today,
+      members: ["USER_ID1", "USER_ID2"],
+      pending_notifications: [
+        PendingNotification.create(strategy: "slack"),
+        PendingNotification.create(strategy: "email")
+      ]
+    )
+
+    older_match = HistoricalMatch.create(
+      grouping: "test",
+      matched_on: Date.today,
+      members: ["USER_ID1", "USER_ID2"],
+      pending_notifications: [
+        PendingNotification.create(strategy: "slack"),
+        PendingNotification.create(strategy: "email")
+      ],
+      created_at: Date.today - 3.months - 1.day
+    )
+
+    subject = Rakes::RemovesOldMatches.new
+    subject.call
+
+    expect { older_match.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    expect { recent_match.reload }.to_not raise_error
+  end
+end

--- a/spec/models/historical_match_spec.rb
+++ b/spec/models/historical_match_spec.rb
@@ -32,4 +32,25 @@ RSpec.describe HistoricalMatch, type: :model do
     expect(match.valid?).to be true
     expect(match.errors).to be_empty
   end
+
+  describe "older_than scope" do
+    it "returns all records older than the specified date" do
+      HistoricalMatch.create(
+        grouping: "test",
+        matched_on: Date.today,
+        members: ["USER_ID1", "USER_ID2"]
+      )
+
+      older_match = HistoricalMatch.create(
+        grouping: "test",
+        matched_on: Date.today,
+        members: ["USER_ID1", "USER_ID2"],
+        created_at: Date.today - 3.months
+      )
+
+      matches = HistoricalMatch.older_than(Date.today)
+
+      expect(matches).to eq([older_match])
+    end
+  end
 end


### PR DESCRIPTION
Cleans up old records instead of adding the filtering to the matchmaking code.