### PR TITLE
Add client Q branch to matchmaking

### DIFF
--- a/config/matchmaking.yml
+++ b/config/matchmaking.yml
@@ -1,4 +1,9 @@
 default: &default
+  client_q_branch:
+    active: true
+    channel: rotating-client-q-branch
+    schedule: monthly
+    size: 2
   coffee_time:
     active: true
     channel: rotating-coffee-time


### PR DESCRIPTION
We want to try engagement specific Q branch pairing. It'll be just like regular Q branch, but only for agents deployed at a given client. We're trying this as an experiment to see if we can improve knowledge sharing, uncover common patterns, and sharpen our pairing skills.