### PR TITLE
Remove client_q_branch from matchmaking.yml

### DIFF
--- a/config/matchmaking.yml
+++ b/config/matchmaking.yml
@@ -1,9 +1,4 @@
 default: &default
-  client_q_branch:
-    active: true
-    channel: rotating-client-q-branch
-    schedule: monthly
-    size: 2
   coffee_time:
     active: true
     channel: rotating-coffee-time


### PR DESCRIPTION
 Now that double-up supports database backed matchmaking groups, we no longer need client_q_branch in matchmaking.yml. 🥳